### PR TITLE
Use Apache Bahir twitter streaming lib

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -23,9 +23,9 @@
         </dependency>
 
         <dependency> <!-- Spark streaming twitter dependency -->
-            <groupId>org.apache.spark</groupId>
+            <groupId>org.apache.bahir</groupId>
             <artifactId>spark-streaming-twitter_2.11</artifactId>
-            <version>1.6.3</version>
+            <version>2.2.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
When running in intellij, would error out with a ClassNotFoundException.

This is a well documented problem apparently: https://stackoverflow.com/questions/38893655/spark-twitter-streaming-exception-org-apache-spark-logging-classnotfound. The apache spark version for twitter streaming doesn't support Spark 2 (which moved the Logging class), would need to downgrade to 1.6 (seems like a lot of new features to lose). [Apache Bahir](http://bahir.apache.org/) seems to get around this.